### PR TITLE
Aktualisierte Informationen nach Bonn

### DIFF
--- a/content/home.md
+++ b/content/home.md
@@ -1,4 +1,4 @@
-+++
+﻿+++
 title = "ZaPF e.v."
 type  = "home"
 +++
@@ -7,8 +7,8 @@ Herzlich Willkommen auf der Website *zapfev.de*! Hier finden Sie Informationen z
 
 Wenn von der ZaPF die Rede ist, ist meist die Zusammenkunft aller (deutschsprachigen) Physik-Fachschaften gemeint. Sie findet halbjährlich an einer Hochschule im deutschsprachigen Raum statt. Weitere Informationen finden sich unter dem Menüpunkt [Die ZaPF](./zapf "Die ZaPF").
 
-Die nächste ZaPF findet vom 07.06. bis 11.06.2019 in *Bonn* statt. Weitere Informationen gibt es [hier](https://zapf.wiki/SoSe19 "ZaPF Sommer19 Bonn").
+Die nächste ZaPF findet vom 31.10 bis 03.11.2019 in *Freiburg* statt. Weitere Informationen gibt es [hier](https://zapf.wiki/WiSe19 "ZaPF Winter19 Freiburg").
 
-Die übernächste ZaPF findet vom 31.10. bis 03.11.2019 in *Freiburg* statt. Mehr Informationen gibt es [hier](https://zapf.wiki/WiSe19 "ZaPF Winter19 Freiburg").
+Die übernächste ZaPF findet vom 20.05. bis 24.05.2020 in *Rostock* statt. Mehr Informationen gibt es [hier](https://zapf.wiki/SoSe20 "ZaPF Sommer20 Rostock").
 
 Der Verein - ZaPF e.V. - wird unter dem Menüpunkt [Der Verein](./verein "Der Verein") genauer vorgestellt.

--- a/content/verein/vorstand.md
+++ b/content/verein/vorstand.md
@@ -1,19 +1,20 @@
-+++
+﻿+++
 title = "Vorstand"
 date = "2016-11-30T13:50:00+01:00"
 +++
 
 
-Auf der Mitgliederversammlung am 02. Juni 2018 in Heidelberg wurden folgende Personen in den Vorstand des ZaPF e.V. gewählt:
+Auf der Mitgliederversammlung am 13. Juli 2019 in Hohen Neuendorf, Ortsteil Borgsdorf wurden folgende Personen in den Vorstand des ZaPF e.V. gewählt:
 
-* Frederike Kubandt (1. Vorsitzende)
-* Laura Lauf (2. Vorsitzende)
+* Peter Steinmüller (1. Vorsitzender)
+* Daniela Kern-Michler (2. Vorsitzende)
 * Jens Borgemeister (1. Kassenwart)
 * Marcus Mikorski (2. Kassenwart)
-* Jan Luca Naumann
-* Johannes Fleck
 * Jan Gräfje
+* Fabian Freyer
 * Andreas Drotloff
 * Tobias Löffler
 * Lisa Dietrich
-* Elisabeth Schlottmann
+* Marcel Nitsch
+* Timo Rachel
+* Richard Altenkirch


### PR DESCRIPTION
Der Vorstand des ZaPF eV wurde neu gewählt und jetzt auf der Homepage
eingetragen, außerdem Anpassung der Daten der nächsten ZaPFen.