### PR TITLE
Texte zu kommenden ZaPFen aktuallisiert

### DIFF
--- a/content/home.md
+++ b/content/home.md
@@ -10,8 +10,8 @@ Wenn von der ZaPF die Rede ist, ist meist die Zusammenkunft aller (deutschsprach
 Der Verein - ZaPF e.V. - wird unter dem Menüpunkt [Der Verein](./verein "Der Verein") genauer vorgestellt.
 
 ---
-### ZaPF im Sommersemester 2021 an der Uni Rostock
+### ZaPF im Sommersemester 2022 in Bochum
 
-Trotz der dynamischen Reaktionen auf die Corona-Pandemie wird die ZaPF als Ostsee-ZaPF von der Uni Rostock und der TU Greifswald geplant. Angedacht ist die Tagung für den Mai 2021, wobei ein genaueres Datum und die Form der Tagung noch nicht fest stehen. Auch wenn eine Präsenzveranstaltung zum Austausch und der Meinungsfindung wünschenswert ist, waren vergangene digitale Formate ebenfalls zielführend. 
-Weitere Infos und Neuigkeiten sind auf der Webseite der [Ostsee-ZaPF](https://ostsee.zapf.in) zu finden. 
+Die Sommer-ZapF 2022 findet in Bochum statt. Geplant ist der Zeitraum vom 03. bis 07. Juni 2022.
+Sobald die Webseite entstanden ist, wird sie an dieser Stelle verlinkt sein.
 

--- a/content/zapf/_index.md
+++ b/content/zapf/_index.md
@@ -6,10 +6,20 @@ menu = "main"
 Die Zusammenkunft aller deutschsprachigen Physik-Fachschaften, kurz ZaPF, ist die deutsche Bundesfachschaftstagung für die Physik. Eine [Liste der Physik-Fachschaften](http://zapf.wiki/Liste_der_Physik-Fachschaften) findet sich im [ZaPF Wiki](http://zapf.wiki). Gleichzeitig versteht sich die ZaPF eben auch als die Zusammenkunft aller deutschsprachigen Fachschaften, also gehören auch die Fachschaften aus der Schweiz und Österreich dazu! Als Vertretung zwischen den halbjährlich stattfindenden ZaPFen wird auf jeder ZaPF der StAPF gewählt, der die ZaPF vertritt.
 
 ---
-### ZaPF im Wintersemester 2020 an der TU München
+### ZaPF im Sommersemester 2022 in Bochum
 
-Vom 5.11.-9.11. findet die ZaPF in Garching bei München in kleinerem Rahmen statt. Dabei werden Präsenzveranstaltungen auch digital zugänglich gemacht, damit möglichst viele Fachschaftsvertreter trotz der erschwerten Bedingungen mitdiskutieren und sich austauschen können. 
-Weitere Infos sind auf der Webseite der [ZaPF in Garching](https://garching.zapf.in) zu finden. 
+Die Sommer-ZapF 2022 findet in Bochum statt. Geplant ist der Zeitraum vom 03. bis 07. Juni 2022. 
+Sobald die Webseite entstanden ist, wird sie an dieser Stelle verlinkt sein.
+
+### ZaPF im Wintersemester 2022 in Hamburg
+
+Vom 10. bis 13. November 2022 findet die Winter-ZaPF in Hamburg statt.
+
+
+### ZaPF im Sommersemester 2023 in Berlin
+
+Im Sommersemester 2023 wird die ZaPF in Berlin stattfinden. 
+Sie wird zusammen von der Humboldt-Universität, der Technischen Universität Berlin, der Freien Universität und der Universität Potsdam geplant.
 
 ---
 


### PR DESCRIPTION
Es war noch Rostock und Garching hinterlegt