### PR TITLE
zapfen angepasst, stapf mitglieder aktuallisiert

### DIFF
--- a/content/home.md
+++ b/content/home.md
@@ -10,8 +10,8 @@ Wenn von der ZaPF die Rede ist, ist meist die Zusammenkunft aller (deutschsprach
 Der Verein - ZaPF e.V. - wird unter dem Menüpunkt [Der Verein](./verein "Der Verein") genauer vorgestellt.
 
 ---
-### ZaPF im Sommersemester 2022 in Bochum
+### ZaPF im Wintersemester 2022 in Hamburg
 
-Die Sommer-ZapF 2022 findet in Bochum statt. Geplant ist der Zeitraum vom 03. bis 07. Juni 2022.
+Die Winter-ZapF 2022 findet in Hamburg statt. Geplant ist der Zeitraum vom 10. bis 13. November 2022.
 Sobald die Webseite entstanden ist, wird sie an dieser Stelle verlinkt sein.
 

--- a/content/zapf/_index.md
+++ b/content/zapf/_index.md
@@ -6,10 +6,6 @@ menu = "main"
 Die Zusammenkunft aller deutschsprachigen Physik-Fachschaften, kurz ZaPF, ist die deutsche Bundesfachschaftstagung für die Physik. Eine [Liste der Physik-Fachschaften](http://zapf.wiki/Liste_der_Physik-Fachschaften) findet sich im [ZaPF Wiki](http://zapf.wiki). Gleichzeitig versteht sich die ZaPF eben auch als die Zusammenkunft aller deutschsprachigen Fachschaften, also gehören auch die Fachschaften aus der Schweiz und Österreich dazu! Als Vertretung zwischen den halbjährlich stattfindenden ZaPFen wird auf jeder ZaPF der StAPF gewählt, der die ZaPF vertritt.
 
 ---
-### ZaPF im Sommersemester 2022 in Bochum
-
-Die Sommer-ZapF 2022 findet in Bochum statt. Geplant ist der Zeitraum vom 03. bis 07. Juni 2022. 
-Sobald die Webseite entstanden ist, wird sie an dieser Stelle verlinkt sein.
 
 ### ZaPF im Wintersemester 2022 in Hamburg
 
@@ -20,6 +16,10 @@ Vom 10. bis 13. November 2022 findet die Winter-ZaPF in Hamburg statt.
 
 Im Sommersemester 2023 wird die ZaPF in Berlin stattfinden. 
 Sie wird zusammen von der Humboldt-Universität, der Technischen Universität Berlin, der Freien Universität und der Universität Potsdam geplant.
+
+### ZaPF im Wintersemester 2023 in Düsseldorf
+
+Im Wintersemester 2023 wird die ZaPF in Düsseldorf stattfinden.
 
 ---
 

--- a/content/zapf/stapf.md
+++ b/content/zapf/stapf.md
@@ -9,17 +9,16 @@ Der *Ständige Ausschuss der Physik-Fachschaften*, kurz der StAPF, vertritt die 
 
 Der StAPF besteht aktuell aus den folgenden fünf Studierenden:
 
-In der Amtsperiode Sommer 2021 bis Sommer 2022 (Gewählt: 13.06.2021 auf dem Abschlussplenum der Sommer-ZaPF 2021 in Rostock:
-
-- Wanda Witte
-- Niklas Jamborek
-- Leon Nutzinger
-
 In der Amtsperiode Winter 2021 bis Winter 2022 (Gewählt: 4.12.2021 auf dem Abschlussplenum der Winter-ZaPF 2021 in Göttingen):
 
 - Sophie Penger
 - Maximilian Schneider
 
+In der Amtsperiode Sommer 2022 bis Sommer 2023 (Gewählt: 7.06.2021 auf dem Abschlussplenum der Sommer-ZaPF 2022 in Bochum:
+
+- Charlotte Geiger
+- Niklas Jamborek
+- Jean-Pascal Scherer
 
 ## Mehr Informationen und Kontakt
 


### PR DESCRIPTION
Bochumer ZaPF rausgenommen. Auf der Hauptseite mit Hamburg ersetzt und unter "Die ZaPF" Bochum raus und Düsseldorf rein. StAPF mitglieder auf StAPF Seite akutallisiert.