### PR TITLE
Vereinssatzung als submodule fix #1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,6 @@
 [submodule "static/berichte"]
 	path = static/berichte
 	url = https://github.com/ZaPF/ZaPF_Berichte.git
-[submodule "static/vereinssatzung"]
-	path = static/vereinssatzung
+[submodule "content/verein/satzung"]
+	path = content/verein/satzung
 	url = https://github.com/ZaPF/Satzung_des_ZaPFev.git


### PR DESCRIPTION
Verschieben des Submodules für die Vereinssatzung in den _content_ Ordner, damit zola die Markdown-Datei als html Datei rendert