### PR TITLE
Berichtungung Vereinsname

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,7 +7,7 @@ theme = "zapf"
 [params]
 # You can use markdown here.
 brand = "ZaPF e.V."
-topline = "Zusammenkunft aller Physik-Fachschaften"
+topline = "Zusammenkunft aller Physik Fachschaften"
 
 # Sidebar position
 # false, true, "left", "right"

--- a/content/home.md
+++ b/content/home.md
@@ -1,5 +1,5 @@
 ﻿+++
-title = "ZaPF e.v."
+title = "ZaPF e.V."
 type  = "home"
 +++
 

--- a/content/impressum.md
+++ b/content/impressum.md
@@ -18,7 +18,7 @@ E-Mail: [vorstand@zapfev.de](mailto:vorstand@zapfev.de)
 
 ## Vereinsregistereintrag
 
-Der Verein Zusammenkunft aller Physik-Fachschaften (ZaPF) ist beim AG Frankfurt/Main auf dem Registerblatt VR 14547 eingetragen.
+Der Verein Zusammenkunft aller Physik Fachschaften (ZaPF) ist beim AG Frankfurt/Main auf dem Registerblatt VR 14547 eingetragen.
 Von 1999 bis 2010 war der Sitz des Vereines in Bochum. Die Eintragung beim Amtsgericht Bochum erfolgte seinerzeit auf dem Registerblatt VR 3175.
 
 ## Freistellungsbescheid


### PR DESCRIPTION
Teresa hat darauf aufmerksam gemacht, dass der e.V. ohne Bindestrich geschrieben wird. Die ZaPF selbst jedoch schon. Das habe ich jetzt für die Webseite abgebildet.