### PR TITLE
Change deprecated .Site.DisqusShortname to .Site.Config.Services.Disqus.Shortname

### DIFF
--- a/themes/zapf/layouts/partials/base/scripts.html
+++ b/themes/zapf/layouts/partials/base/scripts.html
@@ -1,4 +1,4 @@
-{{ with .Site.DisqusShortname }}
+{{ with .Site.Config.Services.Disqus.Shortname }}
 <script type="text/javascript">
   (function() {
     // Don't ever inject Disqus on localhost--it creates unwanted

--- a/themes/zapf/layouts/partials/modules/disqus.html
+++ b/themes/zapf/layouts/partials/modules/disqus.html
@@ -1,4 +1,4 @@
-{{ with .Site.DisqusShortname }}
+{{ with .Site.Config.Services.Disqus.Shortname }}
 <div id="disqus_thread"></div>
 <script type="text/javascript">
   (function() {


### PR DESCRIPTION
Brauchte ich um die Seite lokal bauen zu können.