### PR TITLE
Nutze menschenlesbare Dateinamen an Stelle von index.md

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -23,3 +23,14 @@ highlight = "default"
 
 # Sidebar social links.
 github = "ZaPF" # Your Github profile ID
+
+[module]
+  [[module.mounts]]
+    source = 'content'
+    target = 'content'
+  [[module.mounts]]
+    source = 'content/zapf/satzung/satzung.md'
+    target = 'content/zapf/satzung.md'
+  [[module.mounts]]
+    source = 'content/zapf/go/go.md'
+    target = 'content/zapf/go.md'


### PR DESCRIPTION
Die Repos für GO und Satzung wurde geräumt um sie als Submodules nutzbar zu machen und haben so viel nebenständige Information verloren. Durch den Trick die Dateien durch Hugo mounts an anderer Stelle auftauchen zu lassen, kann man sie ohne diese Änderungen einbinden.